### PR TITLE
Update styles.scss

### DIFF
--- a/assets/scss/galleriesdeluxe/styles.scss
+++ b/assets/scss/galleriesdeluxe/styles.scss
@@ -111,7 +111,7 @@ header {
 
 .galleries {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   grid-gap: 0.5rem;
 
   a {


### PR DESCRIPTION
having this value set to 400px was causing horizontal scrolling in some instances on mobile devices, changing it to 350px fixes that problem.

I am using this on a project of my own and fixed the problem by overriding it on my own in vars-custom.scss, but then I checked on your demo and it was having the same issue so I figured I would offer the fix back to you.

Thank you for all of the amazing work you do on Hugo, I am extremely grateful for you and your commitment to open source software.